### PR TITLE
Add PHP FPM versions 8.2 and 8.3

### DIFF
--- a/snippets/php/8.2
+++ b/snippets/php/8.2
@@ -1,0 +1,4 @@
+location ~ \.php$ {
+	fastcgi_pass unix:/var/run/php/php8.2-fpm.sock;
+	include snippets/php/fastcgi;
+}

--- a/snippets/php/8.3
+++ b/snippets/php/8.3
@@ -1,0 +1,4 @@
+location ~ \.php$ {
+	fastcgi_pass unix:/var/run/php/php8.3-fpm.sock;
+	include snippets/php/fastcgi;
+}


### PR DESCRIPTION
This pull request adds support for PHP FPM versions 8.2 and 8.3. It includes the necessary configuration changes to enable fastcgi_pass for these versions.